### PR TITLE
#85 fetching and displaying carousel images on plant page

### DIFF
--- a/app/components/ProductImage.tsx
+++ b/app/components/ProductImage.tsx
@@ -1,21 +1,17 @@
-import type {ProductVariantFragment} from 'storefrontapi.generated';
 import {Image} from '@shopify/hydrogen';
 
-export function ProductImage({
-  image,
-}: {
-  image: ProductVariantFragment['image'];
-}) {
+export function ProductImage({image, key, alt}: ProductImageProps) {
   if (!image) {
-    return <div className="product-image" />;
+    return <div className="product-image"></div>;
   }
+
   return (
     <div className="product-image">
       <Image
-        alt={image.altText || 'Product Image'}
+        alt={alt}
         aspectRatio="1/1"
         data={image}
-        key={image.id}
+        key={key}
         sizes="(min-width: 45em) 50vw, 100vw"
       />
     </div>

--- a/app/lib/context.ts
+++ b/app/lib/context.ts
@@ -58,5 +58,12 @@ export async function createAppLoadContext(
   return {
     ...hydrogenContext,
     // You can spread in other custom things if needed (like your own database client)
+    // expose custom env variables so they are available in context.env
+    env: {
+      ...env,
+      FILES_ADMIN_API_ACCESS_TOKEN: env.FILES_ADMIN_API_ACCESS_TOKEN,
+      FILES_ADMIN_API_KEY: env.FILES_ADMIN_API_KEY,
+      FILES_ADMIN_API_SECRET_KEY: env.FILES_ADMIN_API_SECRET_KEY,
+    },
   };
 }

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -154,12 +154,18 @@ export default function Plant() {
     }
   }, [product.id, product.title]);
 
+  // Each plant image is a Shopify file object. Each object has a .image.url that must be named with the following structure
+  // `plants--${product.handle}--YYYY-MM-DD--${imageType}--${index}.${fileExtension}`
+  // For example: plants--mammillaria-crucigera-tlalocii-3--2025-05-25--carousel--001.webp
   const unsortedPlantImages = adminImageData.filter((img) =>
     img.image?.url?.includes(`plants--${product.handle}`),
   );
 
-  // each plant image is a Shopify file object. Each object has a .image.url that must be named with the following structure
-  // `plants--${product.handle}--YYYY-MM-DD--${imageType}--001.${fileExtension}`
+  // Since unSortedPlantImages is only concerned about the first two parts of the image url, the sorting logic
+  // will only be concerned about the latter 3 parts of the url:
+  //   - date
+  //   - image type
+  //   - index
   // where imageType can be either
   //   - carousel
   //   - journal

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -62,8 +62,7 @@ async function loadCriticalData(args: LoaderFunctionArgs) {
 }
 
 /**
- * Load data that is *optional* or can be loaded after initial render.
- * Great for journal entries, growth photos, logs, etc.
+ * Load data that is *optional* and can be deferred initial render.
  *
  * This runs in parallel with `loadCriticalData`, and will be awaited by <Await />.
  */
@@ -83,7 +82,7 @@ function loadDeferredData({context, params}: LoaderFunctionArgs) {
 }
 
 /**
- * async function to grab files uploaded to the store under Content > Files in the admin panel
+ * async function to fetch files uploaded to the Shopify store under Content > Files in the admin panel
  */
 
 async function fetchImagesFromAdminAPI({context}: LoaderFunctionArgs) {
@@ -128,12 +127,12 @@ async function fetchImagesFromAdminAPI({context}: LoaderFunctionArgs) {
  * Hydrated on the client after server-side rendering.
  * Uses the `product` returned from the loader.
  *
- * The component receives the product and deferred journalPromise from useLoaderData().
+ * The component receives the critical product data and deferred journalPromise from useLoaderData().
  * Hydrated client-side after SSR.
  */
 
 export default function Plant() {
-  const {product, journalPromise, adminImageData} =
+  const {product, adminImageData, journalPromise} =
     useLoaderData<typeof loader>();
 
   /**
@@ -170,11 +169,11 @@ export default function Plant() {
   //   - carousel
   //   - journal
   //   - milestone
-  // fileExtension can be any file type, but I am assuming all images will be in .webp format.
+  // fileExtension can be any file type, but in my comments I am assuming all images will be in .webp format.
 
   // This function maps through all the plant images and uses regex to find a file match
-  // If there isn't a match, use general defaults as fallback for metadata
   // If there is a match, enter metadata based on the regex match
+  // If there isn't a match, use general defaults as fallback for metadata
   const sortedPlantImages = unsortedPlantImages
     .map((img) => {
       const regex = /--(\d{4}-\d{2}-\d{2})--([a-z]+)--(\d{3})\./;

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -159,7 +159,7 @@ export default function Plant() {
   );
 
   // each plant image is a Shopify file object. Each object has a .image.url that must be named with the following structure
-  // `plants--${product.handle}--${mediaType}--2025-12-31.webp`
+  // `plants--${product.handle}--YYYY-MM-DD--${mediaType}--01.webp`
   // where mediaType can be either
   //   - carousel
   //   - journal
@@ -171,11 +171,11 @@ export default function Plant() {
 
   const sortedCarouselImages = unsortedCarouselImages.slice().sort((a, b) => {
     const extractInfo = (url: string) => {
-      const match = url.match(/--carousel--(\d{4}-\d{2}-\d{2})--(\d{2})\.webp/);
+      const match = url.match(/--(\d{4}-\d{2}-\d{2})--carousel--(\d{2})\.webp/);
       if (!match) return {date: new Date(0), index: 0}; // fallback
       return {
-        date: new Date(match[1]), // e.g., 2025-05-25
-        index: parseInt(match[2], 10), // e.g., 04
+        date: new Date(match[1]), // extracts date e.g. 2025-12-3l
+        index: parseInt(match[2], 10), // extracts index e.g. 04
       };
     };
 

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -126,15 +126,6 @@ async function fetchFilesFromAdminAPI({context}: LoaderFunctionArgs) {
 
   const json = (await response.json()) as ShopifyFilesResponse;
 
-  // Log response for debugging
-  if (!json?.data?.files?.edges) {
-    console.error(
-      'Unexpected response from Admin API:',
-      JSON.stringify(json, null, 2),
-    );
-    return []; // Return empty array to avoid 500s
-  }
-
   return json.data.files.edges.map((edge: any) => edge.node);
 }
 
@@ -175,8 +166,6 @@ export default function Plant() {
     img.image?.url?.includes(`plants--${product.handle}--carousel--`),
   );
 
-  console.log('carouselImages:', carouselImages);
-
   /**
    * Simple HTML layout showing the plant title and description.
    * Uses Shopify's product.descriptionHtml (trusted, sanitized).
@@ -189,7 +178,11 @@ export default function Plant() {
       <div dangerouslySetInnerHTML={{__html: product.descriptionHtml}} />
 
       {carouselImages.length > 0 && (
-        <ProductImage image={{...carouselImages[0].image}} />
+        <div className="carousel">
+          {carouselImages.map((img, index) => (
+            <ProductImage key={img.id ?? index} image={{...img.image}} />
+          ))}
+        </div>
       )}
 
       {/* Display metafields like purchase origin, links, etc. */}
@@ -258,6 +251,7 @@ const PRODUCT_QUERY = `#graphql
   query PlantProduct($handle: String!, $metafieldIdentifiers: [HasMetafieldsIdentifier!]!) {
     product(handle: $handle) {
       id
+      title
       handle
       descriptionHtml
       images(first: 1) {

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -174,7 +174,7 @@ export default function Plant() {
 
   // This function maps through all the plant images and uses regex to find a file match
   // If there isn't a match, use general defaults as fallback for metadata
-  // If there is a match, enter metadata based on the regex match and grab the image's alt tag from the Shopify admin API response
+  // If there is a match, enter metadata based on the regex match
   const sortedPlantImages = unsortedPlantImages
     .map((img) => {
       const regex = /--(\d{4}-\d{2}-\d{2})--([a-z]+)--(\d{3})\./;
@@ -187,7 +187,6 @@ export default function Plant() {
             date: new Date(0),
             imageType: '',
             index: 0,
-            alt: img.image.alt || product.title,
           },
         };
       }
@@ -200,7 +199,6 @@ export default function Plant() {
           date: new Date(dateStr),
           imageType,
           index: parseInt(indexStr, 10),
-          alt: img.image.alt || product.title,
         },
       };
     })
@@ -222,6 +220,19 @@ export default function Plant() {
       return aIndex - bIndex;
     });
 
+  const carouselImages = sortedPlantImages.filter(
+    (img) => img.meta?.imageType === 'carousel',
+  );
+
+  const latestCarouselDate =
+    carouselImages.length > 0
+      ? carouselImages[0].meta.date.toISOString().split('T')[0]
+      : null;
+
+  const latestCarouselImages = carouselImages.filter(
+    (img) => img.meta.date.toISOString().split('T')[0] === latestCarouselDate,
+  );
+
   /**
    * Simple HTML layout showing the plant title and description.
    * Uses Shopify's product.descriptionHtml (trusted, sanitized).
@@ -233,10 +244,14 @@ export default function Plant() {
       <h1>{product.title}</h1>
       <div dangerouslySetInnerHTML={{__html: product.descriptionHtml}} />
 
-      {sortedPlantImages.length > 0 && (
-        <div className="carousel">
-          {sortedPlantImages.map((img, index) => (
-            <ProductImage key={img.id ?? index} image={{...img.image}} />
+      {latestCarouselImages.length > 0 && (
+        <div>
+          {latestCarouselImages.map((img, index) => (
+            <ProductImage
+              key={img.id ?? index}
+              image={{...img.image}}
+              alt={img.alt || `${product.title} image`}
+            />
           ))}
         </div>
       )}

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -16,13 +16,13 @@ import {ProductImage} from '~/components/ProductImage';
 export async function loader(args: LoaderFunctionArgs) {
   const criticalData = await loadCriticalData(args); // Must-have data, required immediately to render
   const deferredData = loadDeferredData(args); // Optional data, can be loaded in parallel
-  const fileImages = await fetchFilesFromAdminAPI(args);
+  const carouselImageData = await fetchCarouselImagesFromAdminAPI(args);
 
   // Return both, including the deferred data wrapped as a promise
   return {
     ...criticalData,
     journalPromise: deferredData.journalPromise,
-    fileImages,
+    carouselImageData,
   };
 }
 
@@ -84,7 +84,7 @@ function loadDeferredData({context, params}: LoaderFunctionArgs) {
  * async function to grab files uploaded to the store under Content > Files in the admin panel
  */
 
-async function fetchFilesFromAdminAPI({context}: LoaderFunctionArgs) {
+async function fetchCarouselImagesFromAdminAPI({context}: LoaderFunctionArgs) {
   const ADMIN_API_URL = `https://${context.env.PUBLIC_STORE_DOMAIN}/admin/api/2025-04/graphql.json`;
   const response = await fetch(ADMIN_API_URL, {
     method: 'POST',
@@ -131,7 +131,8 @@ async function fetchFilesFromAdminAPI({context}: LoaderFunctionArgs) {
  */
 
 export default function Plant() {
-  const {product, journalPromise, fileImages} = useLoaderData<typeof loader>();
+  const {product, journalPromise, carouselImageData} =
+    useLoaderData<typeof loader>();
 
   /**
    * Analytics: track page view when the plant page is viewed.
@@ -151,7 +152,7 @@ export default function Plant() {
     }
   }, [product.id, product.title]);
 
-  const carouselImages = fileImages.filter((img) =>
+  const carouselImages = carouselImageData.filter((img) =>
     img.image?.url?.includes(`plants--${product.handle}--carousel--`),
   );
 

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -98,23 +98,12 @@ async function fetchFilesFromAdminAPI({context}: LoaderFunctionArgs) {
           files(first: 100) {
             edges {
               node {
-                __typename
                 ... on MediaImage {
                   id
                   alt
                   image {
                     url
                   }
-                }
-                ... on GenericFile {
-                  id
-                  alt
-                  fileStatus
-                  preview {
-                    image {
-                      url
-                    }
-                  } 
                 }
               }  
             }

--- a/app/routes/plants.$handle.tsx
+++ b/app/routes/plants.$handle.tsx
@@ -49,16 +49,16 @@ async function loadCriticalData(args: LoaderFunctionArgs) {
   };
 
   // Shopify storefront query using product handle
-  const [{product}, carouselImageData] = await Promise.all([
+  const [{product}, adminImageData] = await Promise.all([
     storefront.query(PRODUCT_QUERY, {variables}),
-    fetchCarouselImagesFromAdminAPI(args),
+    fetchImagesFromAdminAPI(args),
   ]);
 
   if (!product?.id) {
     throw new Response(null, {status: 404});
   }
 
-  return {product, carouselImageData};
+  return {product, adminImageData};
 }
 
 /**
@@ -86,7 +86,7 @@ function loadDeferredData({context, params}: LoaderFunctionArgs) {
  * async function to grab files uploaded to the store under Content > Files in the admin panel
  */
 
-async function fetchCarouselImagesFromAdminAPI({context}: LoaderFunctionArgs) {
+async function fetchImagesFromAdminAPI({context}: LoaderFunctionArgs) {
   const ADMIN_API_URL = `https://${context.env.PUBLIC_STORE_DOMAIN}/admin/api/2025-04/graphql.json`;
   const response = await fetch(ADMIN_API_URL, {
     method: 'POST',
@@ -133,7 +133,7 @@ async function fetchCarouselImagesFromAdminAPI({context}: LoaderFunctionArgs) {
  */
 
 export default function Plant() {
-  const {product, journalPromise, carouselImageData} =
+  const {product, journalPromise, adminImageData} =
     useLoaderData<typeof loader>();
 
   /**
@@ -154,7 +154,7 @@ export default function Plant() {
     }
   }, [product.id, product.title]);
 
-  const carouselImages = carouselImageData.filter((img) =>
+  const carouselImages = adminImageData.filter((img) =>
     img.image?.url?.includes(`plants--${product.handle}--carousel--`),
   );
 

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -657,7 +657,15 @@ export type PlantProductQueryVariables = StorefrontAPI.Exact<{
 
 export type PlantProductQuery = {
   product?: StorefrontAPI.Maybe<
-    Pick<StorefrontAPI.Product, 'id' | 'title' | 'descriptionHtml'> & {
+    Pick<StorefrontAPI.Product, 'id' | 'handle' | 'descriptionHtml'> & {
+      images: {
+        nodes: Array<
+          Pick<
+            StorefrontAPI.Image,
+            'id' | 'url' | 'altText' | 'width' | 'height'
+          >
+        >;
+      };
       metafields: Array<
         StorefrontAPI.Maybe<
           Pick<StorefrontAPI.Metafield, 'namespace' | 'key' | 'value' | 'type'>
@@ -1247,7 +1255,7 @@ interface GeneratedQueryTypes {
     return: PageQuery;
     variables: PageQueryVariables;
   };
-  '#graphql\n  query PlantProduct($handle: String!, $metafieldIdentifiers: [HasMetafieldsIdentifier!]!) {\n    product(handle: $handle) {\n      id\n      title\n      descriptionHtml\n      metafields(identifiers: $metafieldIdentifiers) {\n        namespace\n        key\n        value\n        type\n      }\n    }\n  }\n': {
+  '#graphql\n  query PlantProduct($handle: String!, $metafieldIdentifiers: [HasMetafieldsIdentifier!]!) {\n    product(handle: $handle) {\n      id\n      handle\n      descriptionHtml\n      images(first: 1) {\n        nodes {\n          id\n          url\n          altText\n          width\n          height\n        }\n      }\n      metafields(identifiers: $metafieldIdentifiers) {\n        namespace\n        key\n        value\n        type\n      }\n    }\n  }\n': {
     return: PlantProductQuery;
     variables: PlantProductQueryVariables;
   };

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7,6 +7,12 @@ declare global {
     };
   }
 
+  interface Env {
+    FILES_ADMIN_API_ACCESS_TOKEN: string;
+    FILES_ADMIN_API_KEY: string;
+    FILES_ADMIN_API_SECRET_KEY: string;
+  }
+
   // Type definition for individual journal entries
   type PlantJournalEntry = {
     date: string;
@@ -20,5 +26,20 @@ declare global {
     key: string;
     value: string;
     type: string;
+  };
+
+  type ShopifyFilesResponse = {
+    data: {
+      files: {
+        edges: Array<{
+          node: {
+            id: string;
+            url: string;
+            alt?: string;
+            createdAt: string;
+          };
+        }>;
+      };
+    };
   };
 }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,3 +1,5 @@
+import {ProductVariantFragment} from 'storefrontapi.generated';
+
 export {};
 
 declare global {
@@ -12,6 +14,12 @@ declare global {
     FILES_ADMIN_API_KEY: string;
     FILES_ADMIN_API_SECRET_KEY: string;
   }
+
+  type ProductImageProps = {
+    image: ProductVariantFragment['image'];
+    key?: string | number;
+    alt?: string;
+  };
 
   // Type definition for individual journal entries
   type PlantJournalEntry = {


### PR DESCRIPTION
1. Added new .env variables
2. Added new type for new .env variables and new interface for the Shopify fetch file response structure
3. added a new async function to fetch file images from shopify admin
4. added fetch to loader function
5. filtered fetch response for the correct images for plant page
6. sorted images by date, image type (carousel, journal, milestone, etc) by abc order, and by index
7. filter by latest batch of carousel images
8. display latest carousel images only on the product page
